### PR TITLE
Deprecated: array_key_exists()

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -484,7 +484,7 @@ function game_grade_item_update($game, $grades=null) {
         }
     }
 
-    if (array_key_exists('cmidnumber', $game)) { // Tt may not be always present.
+    if (property_exists($game, 'cmidnumber')) { // Tt may not be always present.
         $params = array('itemname' => $game->name, 'idnumber' => $game->cmidnumber);
     } else {
         $params = array('itemname' => $game->name);


### PR DESCRIPTION
Deprecated: array_key_exists(): Using array_key_exists() on objects is deprecated.

Use isset() or property_exists() instead in [sitedir]/mod/game/lib.php on line 487

Swapping:
```
array_key_exists('cmidnumber', $game)
```
With:
```
property_exists($game, 'cmidnumber')
```